### PR TITLE
Fix mobile header logo overlap and sizing issues

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import Footer from "@/components/Footer"
 
 export default function Home() {
   return (
-    <main className="min-h-screen pt-16">
+    <main className="min-h-screen pt-14 md:pt-16">
       <Navbar />
       <Hero />
       <Services />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import Footer from "@/components/Footer"
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen pt-16">
       <Navbar />
       <Hero />
       <Services />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -37,7 +37,7 @@ export default function Navbar() {
                 alt="Tri Mobile Detail"
                 width={480}
                 height={144}
-                className="brand-logo h-[144px] w-auto"
+                className="brand-logo h-10 sm:h-12 md:h-14 w-auto"
               />
             </a>
           </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -29,15 +29,15 @@ export default function Navbar() {
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
+        <div className="flex justify-between items-center h-14 md:h-16">
           <div className="flex items-center">
-            <a href="/" className="brand-link inline-flex items-center">
+            <a href="/" className="brand-link inline-flex items-center mr-2 md:mr-4">
               <Image
                 src="https://cdn.builder.io/api/v1/image/assets%2F5c758e804cba4fa3a488e9088887877b%2Fe1f1d1f5587d48f6ab6869cb400c4cab?format=webp&width=800"
                 alt="Tri Mobile Detail"
                 width={480}
                 height={144}
-                className="brand-logo h-10 sm:h-12 md:h-14 w-auto"
+                className="brand-logo h-8 sm:h-10 md:h-12 lg:h-14 w-auto object-contain"
               />
             </a>
           </div>


### PR DESCRIPTION
## Purpose
Fix mobile view header logo issues where the logo was overlapping with hero text and appearing too large on smaller screens. The user requested to make the logo smaller to prevent screen cutoff and specifically address mobile view overlap problems.

## Code changes
- **Main layout**: Added responsive top padding (`pt-14 md:pt-16`) to prevent content overlap
- **Navbar height**: Reduced mobile navbar height from 16 to 14 units while maintaining desktop size
- **Logo sizing**: Implemented responsive logo scaling from `h-8` on mobile up to `h-14` on large screens
- **Logo spacing**: Added responsive right margin (`mr-2 md:mr-4`) for better layout
- **Logo styling**: Added `object-contain` class to maintain aspect ratio during scalingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/84dd5d612df242e6b753aee86c36a579/vortex-sanctuary)

👀 [Preview Link](https://84dd5d612df242e6b753aee86c36a579-vortex-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>84dd5d612df242e6b753aee86c36a579</projectId>-->
<!--<branchName>vortex-sanctuary</branchName>-->